### PR TITLE
TEXT token bugfix

### DIFF
--- a/qadil/Lexer.py
+++ b/qadil/Lexer.py
@@ -53,8 +53,10 @@ class Lexer(Macros, Verbatim):
                 self.pos = match.end(0)
                 return
 
-        lineno = self.countlines(self.pos)    
-        raise LexerException("Unknown token:"+self.inputstring[self.pos: self.pos+10], lineno)
+        raise LexerException(
+            "Unknown token:"+self.inputstring[self.pos:].split()[0],
+            self.countlines(self.pos)
+        )
 
     #
     # Functions at tokenize level:

--- a/qadil/Tokens.py
+++ b/qadil/Tokens.py
@@ -4,7 +4,7 @@ NEVER_MATCHES = r'(?!x)x'
 
 class TokenType:
 
-    def __init__(self, name, rege):
+    def __init__(self, name, rege=None):
         self.name = name
         if rege:
             self.rege = re.compile(rege)

--- a/qadil/Tokens.py
+++ b/qadil/Tokens.py
@@ -1,8 +1,10 @@
 import re
 
+NEVER_MATCHES = r'(?!x)x'
+
 class TokenType:
 
-    def __init__(self, name, rege=None):
+    def __init__(self, name, rege):
         self.name = name
         if rege:
             self.rege = re.compile(rege)
@@ -24,7 +26,7 @@ class Token:
     RIGHTBRACKET = TokenType('RIGHTBRACKET', r'\]')
     SPACE = TokenType('SPACE', r'[ \t]')
     WORD = TokenType('WORD', r'[^ \\\{\}\$\%&\n\[\]]+') # Take care of dangling '#' later
-    TEXT = TokenType('TEXT')
+    TEXT = TokenType('TEXT', NEVER_MATCHES)
     
     # Ordering important below! E.g. DISPLAYDELIMITER must come before MATHDELIMITER
     
@@ -52,5 +54,5 @@ class Token:
         self.content = content
 
     def __str__(self):
-        return "<{type}, {content}>".format(type=self.type.name, content=self.content)
+        return "Token(TokenType.{type}, \"{content}\")>".format(type=self.type.name, content=self.content)
 

--- a/qadil/Verbatim.py
+++ b/qadil/Verbatim.py
@@ -55,6 +55,7 @@ class Verbatim:
             lineno = self.countlines(self.pos)
             raise Exception("Tikzpicture environment not ended properly")
 
+    # TODO: code duplication
     def handleverbatim(self):
         
         regex = r'(.*?)\\end\{verbatim\}'

--- a/qadil/tohtml.py
+++ b/qadil/tohtml.py
@@ -23,4 +23,5 @@ doc.translate()
 s = doc.HTML()
 print(s)
 
-
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
The last token, TEXT, didn't have a regex (i.e. it was none).  This meant that in Lexer.getnexttok, if no token matched, it'd try to use the none regex and fail. I assume intended behavior was raising the appropriate LexerException that comes after the loop. I've tried making that happen, by giving TEXT a regex that never matches (according to stackoverflow anyway lol).