### PR TITLE
Additions

### DIFF
--- a/qadil/HTML.py
+++ b/qadil/HTML.py
@@ -214,27 +214,43 @@ class HTML(Writer, Enumerate, Interactive, Bibliography):
         html= self.parsechildren(obj.body)
         
         returnstr = f'<span id="{labelname}"></span>' # for html \href
-        if len(obj.opts) > 0:
-            optname = self.parseopt(obj, 0)
-            if optname == "showhide":
-                Cname = name.capitalize() # css class = name (parameter) capitalized
-                id = uuid4()
-                returnstr += (
-                 f'<a class="{Cname}no" data-count="{labelno}"></a>'
-                 f'<a href="#{id}" class ="btn btn-default {Cname}button" '
-                 'data-toggle="collapse"></a>'
-                 f'<div id={id} class = "collapse {Cname} {self.buttonsclassname}">'
-                 f'  {html}'
-                  '</div>'
-                )
-                return returnstr
+
+        options = []
+        
+        for ix, o in enumerate(obj.opts):
+            options.append(self.parseopt(obj, ix))
+
+        # Adjust name with parameters != "showhide":
+
+        name = name.upper()
+        namec = name.capitalize()
+        for o in options:
+            if not o in ["showhide", "emph"]:
+                name += ' (' + o + ')'
+                namec += ' (' + o + ')'
+
+        # Button?
+                
+        if "showhide" in options:
+            id = uuid4()
+            returnstr += (
+                f'<a class="Genericenvno" data-count="{labelno}" data-name="{name}"></a>'
+                f'<a href="#{id}" class ="btn btn-default Genericenvbutton" '
+                f'data-toggle="collapse" data-name="{namec}"></a>'
+                f'<div id={id} class = "collapse Genericenvbutton {self.buttonsclassname}">'
+                f'  {html}'
+                '</div>'
+            )
+            return returnstr
 
         return (
-            f'{returnstr}'
-            f'<div class="{name}" data-count="{labelno}">'
-            f'     {html}'
-              '</div>'
-            )
+                f'{returnstr}'
+                f'<div class="genericenv" data-count="{labelno}" data-name="{name}">'
+                f'     {html}'
+                '</div>'
+        ) 
+
+
         
     def genericenvstar(self, obj, name):
         html = self.parsechildren(obj.body)
@@ -654,30 +670,44 @@ class HTML(Writer, Enumerate, Interactive, Bibliography):
     @emphasize
     def remark(self, obj):
         return self.genericenv(obj, "remark")        
-    
-    
+
     def sage(self, obj):
         #env
+
+        options = []
+        
+        for ix, o in enumerate(obj.opts):
+            options.append(self.parseopt(obj, ix))
+
+        sageclass = "sage"
+
+        if "M2" in options:
+            sageclass = "sageM2"
+        if "python" in options:
+            sageclass = "sagepython"
+        if "R" in options:
+            sageclass = "sageR"
+            
         self.verbatim = True
-        html = ('<div class="sage">'
+        html = (f'<div class={sageclass}>'
                 '<script type="text/x-sage">'
                f'{self.parsechildren(obj.body)}'
                 '</script>'
                 '</div>'
                 )
         self.verbatim = False
-        if len(obj.opts) > 0:
-            optname = self.parseopt(obj, 0)
+
+        if "showhide" in options:
             name = "sage"
-            if optname == "showhide":
-                Cname = name.capitalize() # see genericenv
-                id = uuid4()
-                returnstr = (
-                    f'<a href="#{id}" class ="btn btn-default {Cname}button" data-toggle="collapse"></a>'
-                    f'<div id={id} class = "collapse {Cname} {self.buttonsclassname}">'
-                )
-                return f"{returnstr}{html}</div>"
+            Cname = name.capitalize() # see genericenv
+            id = uuid4()
+            returnstr = (
+                f'<a href="#{id}" class ="btn btn-default {Cname}button" data-toggle="collapse"></a>'
+                f'<div id={id} class = "collapse {Cname} {self.buttonsclassname}">'
+            )
+            return f"{returnstr}{html}</div>"
         return html
+
 
     def raw(self, text): # Hack for getting control sequences in toc right
         new_text=""

--- a/qadil/Lexer.py
+++ b/qadil/Lexer.py
@@ -97,6 +97,9 @@ class Lexer(Macros, Verbatim):
                 if self.value == "\\begin{code}":
                     self.handlecode()
                     self.getnexttok()
+                if self.value == "\\begin{sage}":
+                    self.handlesage()
+                    self.getnexttok()
                 if self.value == "\\begin{verbatim}":
                     self.handleverbatim()
                     self.getnexttok()

--- a/qadil/Verbatim.py
+++ b/qadil/Verbatim.py
@@ -23,6 +23,40 @@ class Verbatim:
         else:
             lineno = self.countlines(self.pos)
             raise Exception("Code environment not ended properly")
+        
+    def handlesage(self):
+
+        # First handle optional parameters (verbatim)
+
+        regex = r'\[(.*?)\]'
+        regc = re.compile(regex, re.DOTALL)
+        matchopt = regc.match(self.inputstring, self.pos)
+        txtoptlist = []
+
+        while matchopt:
+            txtoptlist.append(matchopt.group(1))
+            self.pos = matchopt.end(0)
+            matchopt = regc.match(self.inputstring, self.pos)
+
+        
+        regex = r'(.*?)\\end\{sage\}'
+        regc = re.compile(regex, re.DOTALL)
+        match = regc.match(self.inputstring, self.pos)
+
+        if match:
+            txt = match.group(1)
+            self.pos = match.end(0)
+            self.tokenlist.append(Token(TokenType("BEGINENV"), "\\begin{sage}"))
+            for t in txtoptlist:
+                self.tokenlist.append(Token(TokenType("LEFTBRACKET"), '['))
+                self.tokenlist.append(Token(TokenType("TEXT"), t))
+                self.tokenlist.append(Token(TokenType("RIGHTBRACKET"), ']'))
+                
+            self.tokenlist.append(Token(TokenType("TEXT"), txt))
+            self.tokenlist.append(Token(TokenType("ENDENV"), "\\end{sage}"))
+        else:
+            lineno = self.countlines(self.pos)
+            raise Exception("Sage environment not ended properly")
 
     def handlehtml(self):
 

--- a/qadil/css/iLaTeXen.css
+++ b/qadil/css/iLaTeXen.css
@@ -174,6 +174,32 @@ figcaption {
   border-width: 1px;
   padding: 10px; }
 
+.Genericenvbutton:before {
+    content: attr(data-name);
+}
+
+.Genericenvno:before {
+    font-weight: bold;
+    font-style: normal;
+    content: "(" attr(data-count) ")  ";
+}
+
+.genericenv {
+  display: block;
+  margin: 12px 0;
+/*  padding: 10px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #ccc; */
+}
+
+.genericenv:before {
+    display:block;
+    content: "(" attr(data-count) ") " attr(data-name);
+    font-weight: bold;
+    font-style: normal;
+    margin-bottom: 20px;
+}
 
 .Hintbutton:before {
     content: "Hint";

--- a/qadil/htmlinclude/sagecell
+++ b/qadil/htmlinclude/sagecell
@@ -6,7 +6,28 @@
   inputLocation: ".sage",
   evalButtonText: "Compute",
   linked: true,
-  languages : ["sage", "python", "macaulay2"],
+  languages : ["sage", "python", "macaulay2", "r"],
+  hide : ["permalink"]
+  });
+  sagecell.makeSagecell({
+  inputLocation: ".sageM2",
+  evalButtonText: "Compute",
+  linked: true,
+  languages : ["macaulay2", "sage", "python", "r"],
+  hide : ["permalink"]
+  });
+  sagecell.makeSagecell({
+  inputLocation: ".sagepython",
+  evalButtonText: "Compute",
+  linked: true,
+  languages : ["python", "sage", "macaulay2", "r"],
+  hide : ["permalink"]
+  });
+  sagecell.makeSagecell({
+  inputLocation: ".sageR",
+  evalButtonText: "Compute",
+  linked: true,
+  languages : ["r", "python", "sage", "macaulay2"],
   hide : ["permalink"]
   });
 </script>

--- a/qadil/js/bubble.js
+++ b/qadil/js/bubble.js
@@ -382,7 +382,7 @@ function refBubbleGetEnvBubbleHTML(model, envId) {
     try {
         className = elementToCopy.classList.item(0);
 
-        if (className == 'Exerciseno') {
+        if (className == 'Exerciseno' || className == 'Genericenvno' || className == 'Exampleno' || className == 'Theoremno') {
             var buttonElement = model.querySelector(`*[data-count="${envId}"] + a`);
             var divId = refBubbleGetHashtag(buttonElement.href);
             


### PR DESCRIPTION
Issue #20 is fixed by adding the `sage` environment as verbatim in `Lexer.py` and `Verbatim.py`. Also, an additional functionality is added. The languages available are `Sage, Macaulay2, python, R`. An optional parameter decides which language appears first in the list i.e.,
```
\begin{sage}[R]
 d <- data.frame(X = 1:10, Y = 11:20)
  x <- d$X
  y <- d$Y
  print(y-x)
\end{sage}
```
puts `R` first. No optional parameter defaults to `Sage` first.

Issue #19 is handled by the addition of a generic environment in `HTML.py` i.e., a new `css` tag: `genericenv` with an attribute `data-name` carrying the name of the environment and its added optional parameter. Example:
```
\begin{theorem}[Pythagoras}
$$
a^2 + b^2 = c^2
$$
\end{theorem}
```
This also works with buttons as `\begin{theorem}[showhide][Pythagoras]`.

It seems that `js/bubble.js` only makes popups for exercises in buttons. This has been adressed in an ad hoc manner (search for `Exerciseno` in `js/bubble.js`.